### PR TITLE
[dotnet-analysis] Updating vulnerability database each time the security analyser is run

### DIFF
--- a/src/security/workflow.yaml
+++ b/src/security/workflow.yaml
@@ -27,7 +27,6 @@ activities:
       - JSON
       - --out
       - /home/dependencycheck
-      - -n
   owaspDependencyChecker-converter:
     image: godeltech/codereview.file-converter
     volumes:


### PR DESCRIPTION
This PR introduces a modification to the `owaspDependencyChecker` activity configuration in the security analysis workflow. The parameter `-n` has been removed from the `command` list for the OWASP Dependency Checker.

The removal of this parameter ensures that the OWASP Dependency Checker updates its vulnerability database each time the security analyzer runs. This change ensures that the analysis is always performed using the most recent vulnerability data, enhancing the accuracy and relevance of security insights.